### PR TITLE
Performance fix

### DIFF
--- a/_posts/2019-05-28-simplefuzzer-01.markdown
+++ b/_posts/2019-05-28-simplefuzzer-01.markdown
@@ -562,6 +562,15 @@ class LimitFuzzer:
         self.grammar = grammar
         self.key_cost = {}
         self.cost = compute_cost(grammar)
+        self.cheap_grammar = {}
+        for k in self.cost:
+            # should we minimize it here? We simply avoid infinities
+            rules = self.grammar[k]
+            min_cost = min([self.cost[k][str(r)] for r in rules])
+            #grammar[k] = [r for r in grammar[k] if self.cost[k][str(r)] == float(&#x27;inf&#x27;)]
+            self.cheap_grammar[k] = [r for r in self.grammar[k] if self.cost[k][str(r)] == min_cost]
+
+
 
 ############
 -->
@@ -589,6 +598,13 @@ class LimitFuzzer:
         self.grammar = grammar
         self.key_cost = {}
         self.cost = compute_cost(grammar)
+        self.cheap_grammar = {}
+        for k in self.cost:
+            # should we minimize it here? We simply avoid infinities
+            rules = self.grammar[k]
+            min_cost = min([self.cost[k][str(r)] for r in rules])
+            #grammar[k] = [r for r in grammar[k] if self.cost[k][str(r)] == float(&#x27;inf&#x27;)]
+            self.cheap_grammar[k] = [r for r in self.grammar[k] if self.cost[k][str(r)] == min_cost]
 </textarea><br />
 <pre class='Output' name='python_output'></pre>
 <div name='python_canvas'></div>
@@ -697,14 +713,6 @@ class LimitFuzzer(LimitFuzzer):
             else:
                 return [t, []]
 
-        cheap_grammar = {}
-        for k in self.cost:
-            # should we minimize it here? We simply avoid infinities
-            rules = self.grammar[k]
-            min_cost = min([self.cost[k][str(r)] for r in rules])
-            #grammar[k] = [r for r in grammar[k] if self.cost[k][str(r)] == float('inf')]
-            cheap_grammar[k] = [r for r in self.grammar[k] if self.cost[k][str(r)] == min_cost]
-
         root = [key, None]
         queue = [(0, root)]
         while queue:
@@ -712,7 +720,7 @@ class LimitFuzzer(LimitFuzzer):
             (depth, item), *queue = queue
             key = item[0]
             if item[1] is not None: continue
-            grammar = self.grammar if depth < max_depth else cheap_grammar
+            grammar = self.grammar if depth < max_depth else self.cheap_grammar
             chosen_rule = random.choice(grammar[key])
             expansion = [get_def(t) for t in chosen_rule]
             item[1] = expansion
@@ -731,14 +739,6 @@ class LimitFuzzer(LimitFuzzer):
             else:
                 return [t, []]
 
-        cheap_grammar = {}
-        for k in self.cost:
-            # should we minimize it here? We simply avoid infinities
-            rules = self.grammar[k]
-            min_cost = min([self.cost[k][str(r)] for r in rules])
-            #grammar[k] = [r for r in grammar[k] if self.cost[k][str(r)] == float(&#x27;inf&#x27;)]
-            cheap_grammar[k] = [r for r in self.grammar[k] if self.cost[k][str(r)] == min_cost]
-
         root = [key, None]
         queue = [(0, root)]
         while queue:
@@ -746,7 +746,7 @@ class LimitFuzzer(LimitFuzzer):
             (depth, item), *queue = queue
             key = item[0]
             if item[1] is not None: continue
-            grammar = self.grammar if depth &lt; max_depth else cheap_grammar
+            grammar = self.grammar if depth &lt; max_depth else self.cheap_grammar
             chosen_rule = random.choice(grammar[key])
             expansion = [get_def(t) for t in chosen_rule]
             item[1] = expansion

--- a/notebooks/2019-05-28-simplefuzzer-01.py
+++ b/notebooks/2019-05-28-simplefuzzer-01.py
@@ -245,6 +245,13 @@ class LimitFuzzer:
         self.grammar = grammar
         self.key_cost = {}
         self.cost = compute_cost(grammar)
+        self.cheap_grammar = {}
+        for k in self.cost:
+            # should we minimize it here? We simply avoid infinities
+            rules = self.grammar[k]
+            min_cost = min([self.cost[k][str(r)] for r in rules])
+            #grammar[k] = [r for r in grammar[k] if self.cost[k][str(r)] == float('inf')]
+            self.cheap_grammar[k] = [r for r in self.grammar[k] if self.cost[k][str(r)] == min_cost]
 
 # Using it:
 
@@ -297,14 +304,6 @@ class LimitFuzzer(LimitFuzzer):
             else:
                 return [t, []]
 
-        cheap_grammar = {}
-        for k in self.cost:
-            # should we minimize it here? We simply avoid infinities
-            rules = self.grammar[k]
-            min_cost = min([self.cost[k][str(r)] for r in rules])
-            #grammar[k] = [r for r in grammar[k] if self.cost[k][str(r)] == float('inf')]
-            cheap_grammar[k] = [r for r in self.grammar[k] if self.cost[k][str(r)] == min_cost]
-
         root = [key, None]
         queue = [(0, root)]
         while queue:
@@ -312,7 +311,7 @@ class LimitFuzzer(LimitFuzzer):
             (depth, item), *queue = queue
             key = item[0]
             if item[1] is not None: continue
-            grammar = self.grammar if depth < max_depth else cheap_grammar
+            grammar = self.grammar if depth < max_depth else self.cheap_grammar
             chosen_rule = random.choice(grammar[key])
             expansion = [get_def(t) for t in chosen_rule]
             item[1] = expansion


### PR DESCRIPTION
Hi Rahul, I think it's enough to precompute `cheap_grammar` once.

```
from simplefuzzer import LimitFuzzer
from orig_simplefuzzer import LimitFuzzer as LimitFuzzerOrig

import random
import time

grammar = {
    "<start>": [["<X>"]],
    "<X>": [["A", "<X>", "B"], []]
}

def main():
    start = time.time()
    random.seed(0)
    gf = LimitFuzzerOrig(grammar)
    for i in range(1000000):
        gf.iter_fuzz(key='<start>', max_depth=10)
    end = time.time()
    orig_diff = end-start

    start = time.time()
    random.seed(0)
    gf = LimitFuzzer(grammar)
    for i in range(1000000):
       gf.iter_fuzz(key='<start>', max_depth=10)
    end = time.time()
    fixed_diff = end-start

    print("Orig fuzzer took: ", orig_diff)
    print("Fixed fuzzer took: ", fixed_diff)

if __name__ == "__main__":
    main()
 ```

_Orig fuzzer took:  13.014216423034668
Fixed fuzzer took:  9.508349657058716_
