### PR TITLE
Fixed potential infinite loop in can_abstract()

### DIFF
--- a/notebooks/2020-08-03-simple-ddset.py
+++ b/notebooks/2020-08-03-simple-ddset.py
@@ -93,16 +93,17 @@ def generalize(tree, path, known_paths, grammar, predicate):
 MAX_TRIES_FOR_ABSTRACTION = 100
 
 def can_abstract(tree, path, known_paths, grammar, predicate):
-    i = 0
-    while (i < MAX_TRIES_FOR_ABSTRACTION):
+    for i in range(MAX_TRIES_FOR_ABSTRACTION):
         t = replace_all_paths_with_generated_values(tree, known_paths + [path], grammar)
         s = fuzzer.iter_tree_to_str(t)
-        if predicate(s) == hdd.PRes.failed:
+        result = predicate(s)
+
+        if result == hdd.PRes.failed:
             return False
-        elif predicate(s) == hdd.PRes.invalid:
+        elif result == hdd.PRes.invalid:
             continue
-        i += 1
-    return True
+
+    return True if result == hdd.PRes.success else False
 
 # The `can_abstract()` procedure tries to generate a valid value `MAX_TRIES_FOR_ABSTRACTION` times. For this, it relies on
 # `replace_all_paths_with_generated_values()` which is implemented as follows.

--- a/notebooks/2020-08-03-simple-ddset.py
+++ b/notebooks/2020-08-03-simple-ddset.py
@@ -91,19 +91,26 @@ def generalize(tree, path, known_paths, grammar, predicate):
 # The `can_abstract()` procedure above does the checking to see if the tree can be abstracted. It is implemented as follows.
 
 MAX_TRIES_FOR_ABSTRACTION = 100
+MIN_EXAMPLES = 90
 
 def can_abstract(tree, path, known_paths, grammar, predicate):
-    for i in range(MAX_TRIES_FOR_ABSTRACTION):
+    successes = 0
+
+    for _ in range(MAX_TRIES_FOR_ABSTRACTION):
         t = replace_all_paths_with_generated_values(tree, known_paths + [path], grammar)
         s = fuzzer.iter_tree_to_str(t)
-        result = predicate(s)
+        pres = predicate(s)
 
-        if result == hdd.PRes.failed:
+        if pres == hdd.PRes.failed:
             return False
-        elif result == hdd.PRes.invalid:
+        
+        if pres == hdd.PRes.invalid:
             continue
 
-    return True if result == hdd.PRes.success else False
+        if pres == hdd.PRes.success:
+            successes += 1
+
+    return True if successes >= MIN_EXAMPLES else False
 
 # The `can_abstract()` procedure tries to generate a valid value `MAX_TRIES_FOR_ABSTRACTION` times. For this, it relies on
 # `replace_all_paths_with_generated_values()` which is implemented as follows.


### PR DESCRIPTION
# Problem
The original function could encounter an infinite loop if the predicate always returned invalid.
```python
def can_abstract(tree, path, known_paths, grammar, predicate):
    i = 0
    while (i < MAX_TRIES_FOR_ABSTRACTION):
        t = replace_all_paths_with_generated_values(tree, known_paths + [path], grammar)
        s = fuzzer.iter_tree_to_str(t)
        if predicate(s) == hdd.PRes.failed:
            return False
        elif predicate(s) == hdd.PRes.invalid:
            continue # <-- problem here
        i += 1
    return True
```

# Solution
There appears to be a substantial fix in: [Ewoks](https://github.com/vrthra/Ewoks/blob/master/src/SimpleDDSet.py) in `can_generalize()`.

But my fix may be easier for readers to understand at a first glance.
```python
MAX_TRIES_FOR_ABSTRACTION = 100
MIN_EXAMPLES = 90

def can_abstract(tree, path, known_paths, grammar, predicate):
    successes = 0

    for _ in range(MAX_TRIES_FOR_ABSTRACTION):
        t = replace_all_paths_with_generated_values(tree, known_paths + [path], grammar)
        s = fuzzer.iter_tree_to_str(t)
        pres = predicate(s)

        if pres == hdd.PRes.failed:
            return False
        
        if pres == hdd.PRes.invalid:
            continue

        if pres == hdd.PRes.success:
            successes += 1

    return True if successes >= MIN_EXAMPLES else False
```